### PR TITLE
Enable to assign a name to module

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -129,7 +129,7 @@ mod tests {
         ];
         let binary = binary.into_iter().map(|c| c as u8).collect::<Vec<u8>>();
 
-        let module = Module::from_buf(&runtime, &binary);
+        let module = Module::from_buf(&runtime, &binary, "");
         assert!(module.is_ok());
         let module = module.unwrap();
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -17,9 +17,13 @@ pub fn error_buf_to_string(&error_buf: &[c_char; DEFAULT_ERROR_BUF_SIZE]) -> Str
     String::from_utf8(error_content).unwrap()
 }
 
+pub fn cstr_to_string(raw_cstr: *const c_char) -> String {
+    let cstr = unsafe { CStr::from_ptr(raw_cstr) };
+    String::from_utf8_lossy(cstr.to_bytes()).to_string()
+}
+
 pub fn exception_to_string(raw_exception: *const c_char) -> String {
-    let exception = unsafe { CStr::from_ptr(raw_exception) };
-    String::from_utf8_lossy(exception.to_bytes()).to_string()
+    cstr_to_string(raw_exception)
 }
 
 #[cfg(test)]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -124,7 +124,7 @@ mod tests {
         ];
         let binary = binary.into_iter().map(|c| c as u8).collect::<Vec<u8>>();
 
-        let module = Module::from_buf(&runtime, &binary);
+        let module = Module::from_buf(&runtime, &binary, "add");
         assert!(module.is_ok());
 
         let module = &module.unwrap();
@@ -165,7 +165,7 @@ mod tests {
         ];
         let binary = binary.into_iter().map(|c| c as u8).collect::<Vec<u8>>();
 
-        let module = Module::from_buf(&runtime, &binary);
+        let module = Module::from_buf(&runtime, &binary, "");
         assert!(module.is_ok());
 
         let module = &module.unwrap();
@@ -207,7 +207,7 @@ mod tests {
         ];
         let binary = binary.into_iter().map(|c| c as u8).collect::<Vec<u8>>();
 
-        let module = Module::from_buf(&runtime, &binary);
+        let module = Module::from_buf(&runtime, &binary, "add");
         assert!(module.is_ok());
 
         let module = &module.unwrap();


### PR DESCRIPTION
if a module
- comes from `from_file()`, the file name is its module name
- comes form `from_buf()`, pass the name via the `name` argument