### PR TITLE
Add execution environment

### DIFF
--- a/src/execution_environment.rs
+++ b/src/execution_environment.rs
@@ -1,0 +1,43 @@
+use wamr_sys::{
+    wasm_exec_env_t, wasm_runtime_get_call_stack_buf_size, wasm_runtime_get_exec_env_singleton,
+};
+
+use crate::instance::Instance;
+
+pub struct ExecutionEnvironment(wasm_exec_env_t);
+
+impl ExecutionEnvironment {
+    pub fn from_instance(instance: Instance) -> Self {
+        Self(unsafe { wasm_runtime_get_exec_env_singleton(instance.get_inner_instance()) })
+    }
+
+    /// Set user data for the current execution environment.
+    /// This is useful when you want to pass some data to the host native functions.
+    /// The user data can be retrieved by calling `get_user_data()`.
+    ///
+    /// # Safety
+    /// Be careful when using this function, as it can lead to undefined behavior if misused.
+    pub unsafe fn set_user_data(&self, user_data: *mut std::ffi::c_void) {
+        wamr_sys::wasm_runtime_set_user_data(self.get_inner_execution_environment(), user_data);
+    }
+
+    /// Get user data for the current execution environment.
+    /// This is useful when you want to pass some data to the host native functions.
+    /// The user data can be set by calling `set_user_data()`.
+    ///
+    /// # Safety
+    /// Be careful when using this function, as it can lead to undefined behavior if misused.
+    pub unsafe fn get_user_data(&self) -> *mut std::ffi::c_void {
+        wamr_sys::wasm_runtime_get_user_data(self.get_inner_execution_environment())
+    }
+
+    pub fn get_call_stack_buffer_size(&self) -> usize {
+        unsafe {
+            wasm_runtime_get_call_stack_buf_size(self.get_inner_execution_environment()) as usize
+        }
+    }
+
+    pub(crate) fn get_inner_execution_environment(&self) -> wasm_exec_env_t {
+        self.0
+    }
+}

--- a/src/execution_environment.rs
+++ b/src/execution_environment.rs
@@ -8,7 +8,7 @@ use crate::instance::Instance;
 pub struct ExecutionEnvironment(wasm_exec_env_t);
 
 impl ExecutionEnvironment {
-    pub fn from_instance(instance: Instance) -> Self {
+    pub fn from_instance(instance: &Instance) -> Self {
         Self(unsafe { wasm_runtime_get_exec_env_singleton(instance.get_inner_instance()) })
     }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -12,12 +12,12 @@ use core::ffi::c_char;
 
 use wamr_sys::{
     wasm_module_inst_t, wasm_runtime_deinstantiate, wasm_runtime_destroy_thread_env,
-    wasm_runtime_init_thread_env, wasm_runtime_instantiate,
+    wasm_runtime_get_module_inst, wasm_runtime_init_thread_env, wasm_runtime_instantiate,
 };
 
 use crate::{
-    helper::error_buf_to_string, helper::DEFAULT_ERROR_BUF_SIZE, module::Module, runtime::Runtime,
-    RuntimeError,
+    execution_environment::ExecutionEnvironment, helper::error_buf_to_string,
+    helper::DEFAULT_ERROR_BUF_SIZE, module::Module, runtime::Runtime, RuntimeError,
 };
 
 #[derive(Debug)]
@@ -26,6 +26,17 @@ pub struct Instance {
 }
 
 impl Instance {
+    /// This function get the execution environment from the instance.
+    pub fn from_execution_environment(execution_environment: ExecutionEnvironment) -> Self {
+        Self {
+            instance: unsafe {
+                wasm_runtime_get_module_inst(
+                    execution_environment.get_inner_execution_environment(),
+                )
+            },
+        }
+    }
+
     /// instantiate a module with stack size
     ///
     /// # Error

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -27,7 +27,7 @@ pub struct Instance {
 
 impl Instance {
     /// This function get the execution environment from the instance.
-    pub fn from_execution_environment(execution_environment: ExecutionEnvironment) -> Self {
+    pub fn from_execution_environment(execution_environment: &ExecutionEnvironment) -> Self {
         Self {
             instance: unsafe {
                 wasm_runtime_get_module_inst(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+pub mod execution_environment;
 pub mod function;
 mod helper;
 pub mod host_function;


### PR DESCRIPTION
Hello, while waiting to be able to reflect on the other PR, I think it is necessary to implement a wrapper for `wasm_exec_env_t`. I know it's not safe (no type for `user_data`, only `void`), however, I don't see a way to guarantee safety since WAMR links Rust fn as C functions to WASM.