### PR TITLE
Add custom platform configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,15 @@ keywords = ["api-bindings", "wasm", "webassembly"]
 wamr-sys = { path = "crates/wamr-sys", version = "1.0.0" }
 
 [target.'cfg( target_os = "espidf" )'.dependencies]
-esp-idf-sys = { version = "0.34" }
+esp-idf-sys = { version = "0.34", optional = true }
 
 [[package.metadata.esp-idf-sys.extra_components]]
 bindings_header = "./crates/wamr-sys/wasm-micro-runtime/core/iwasm/include/wasm_export.h"
 component_dirs = ["./crates/wamr-sys/wasm-micro-runtime/build-scripts/esp-idf"]
+
+[features]
+esp-idf = ["esp-idf-sys", "wamr-sys/esp-idf"]
+
 
 # [features]
 # llvmjit = ["wamr-sys/llvmjit"]

--- a/crates/wamr-sys/Cargo.toml
+++ b/crates/wamr-sys/Cargo.toml
@@ -30,5 +30,6 @@ bindgen = "0.69"
 cc = "1.0"
 cmake = "0.1"
 
-# [features]
+[features]
+esp-idf = []
 # llvmjit = []

--- a/crates/wamr-sys/build.rs
+++ b/crates/wamr-sys/build.rs
@@ -39,6 +39,7 @@ fn main() {
 
         if let Ok(platform_config) = env::var("WAMR_SHARED_PLATFORM_CONFIG") {
             dst.define("SHARED_PLATFORM_CONFIG", &platform_config);
+            println!("cargo:rerun-if-changed={}", platform_config);
         }
 
         let dst = dst


### PR DESCRIPTION
Hello,
This PR adds support for custom platforms by setting the environment variables `WAMR_SHARED_PLATFORM_CONFIG` and `WAMR_BUILD_PLATFORM`, which propagate to the WAMR build scripts.