### PR TITLE
Sync wamr to commit 67fa155

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[env]
+# vprintf callback. refer to https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/build_wamr.md?plain=1#L193
+#WAMR_BH_VPRINTF = ""
+# https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/port_wamr.md#wamr-porting-guide
+#WAMR_BUILD_PLATFORM = "new OS name"
+#WAMR_SHARED_PLATFORM_CONFIG = "core/shared/platform/new os/shared_platform.cmake"
+# change it to your own LLVM lib path
+LLVM_LIB_CFG_PATH = "/usr/lib/llvm-15/cmake/"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,10 @@ ENV TZ=Asian/Shanghai
 
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y cmake
+  && apt-get install --no-install-recommends -y cmake gnupg lsb-release software-properties-common wget
 
-# Fix "Unable to find libclang" issue
-RUN apt-get install --no-install-recommends -y clang-11
+RUN cd /tmp \
+  && wget https://apt.llvm.org/llvm.sh \
+  && chmod a+x llvm.sh \
+  && ./llvm.sh 15
+

--- a/.devcontainer/finalize.sh
+++ b/.devcontainer/finalize.sh
@@ -2,7 +2,7 @@ printf "Running 'postCreateCommand' Script\n"
 
 # Install Rust Targets
 printf "Installing Rust Targets\n"
-rustup update stable --no-self-update
+#rustup update stable --no-self-update
 rustup default stable
 rustup target add wasm32-unknown-unknown
 rustup target add wasm32-wasi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ esp-idf-sys = { version = "0.35" }
 bindings_header = "./crates/wamr-sys/wasm-micro-runtime/core/iwasm/include/wasm_export.h"
 component_dirs = ["./crates/wamr-sys/wasm-micro-runtime/build-scripts/esp-idf"]
 
-# [features]
-# llvmjit = ["wamr-sys/llvmjit"]
+[features]
+llvmjit = ["wamr-sys/llvmjit"]

--- a/crates/wamr-sys/Cargo.toml
+++ b/crates/wamr-sys/Cargo.toml
@@ -30,5 +30,6 @@ bindgen = "0.69"
 cc = "1.1"
 cmake = "0.1"
 
-# [features]
-# llvmjit = []
+[features]
+llvmjit = []
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! ### WAMR private concepts
 //!
 //! - *loading linking* instead of *instantiation linking*. *instantiation linking* is
-//! used in Wasm JS API and Wasm C API. It means that every instance has its own, maybe
-//! variant, imports. But *loading linking* means that all instances share the same *imports*.
+//!   used in Wasm JS API and Wasm C API. It means that every instance has its own, maybe
+//!   variant, imports. But *loading linking* means that all instances share the same *imports*.
 //!
 //! - *RuntimeArg*. Control runtime behavior.
 //!   - *running mode*.


### PR DESCRIPTION
The commit will bypass access mode modification of STDIN, STDOUT and STDERR. It will help to enable runwasi to run successfully although we don't know why the sandbox in runwasi will let STDOUT read-only.