### PR TITLE
Add build flag `WAMR_BUILD_MULTI_MODULE`

### DIFF
--- a/crates/wamr-sys/build.rs
+++ b/crates/wamr-sys/build.rs
@@ -26,6 +26,7 @@ fn main() {
             .define("WAMR_BUILD_FAST_INTERP", "1")
             .define("WAMR_BUILD_JIT", enable_llvm_jit)
             // mvp
+            .define("WAMR_BUILD_MULTI_MODULE", "1")
             .define("WAMR_BUILD_BULK_MEMORY", "1")
             .define("WAMR_BUILD_REF_TYPES", "1")
             .define("WAMR_BUILD_SIMD", "1")


### PR DESCRIPTION
I am using wamr-sys directly, but the `WAMR_BUILD_MULTI_MODULE` build flag is missing, so the `wasm_runtime_register_module` function cannot be used.
If there is a problem with this flag being 1 by default, I am considering creating a new feature.