### PR TITLE
Refactor lifetimes in Function, Instance, Module, and Runtime strucs

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -19,18 +19,21 @@ use crate::{
     helper::exception_to_string, instance::Instance, value::WasmValue, ExecError, RuntimeError,
 };
 
-pub struct Function<'a> {
+pub struct Function<'instance> {
     function: wasm_function_inst_t,
-    _phantom: PhantomData<Instance<'a>>,
+    _phantom: PhantomData<Instance<'instance>>,
 }
 
-impl<'a> Function<'a> {
+impl<'instance> Function<'instance> {
     /// find a function by name
     ///
     /// # Error
     ///
     /// Return `RuntimeError::FunctionNotFound` if failed.
-    pub fn find_export_func(instance: &'a Instance<'a>, name: &str) -> Result<Self, RuntimeError> {
+    pub fn find_export_func(
+        instance: &'instance Instance<'instance>,
+        name: &str,
+    ) -> Result<Self, RuntimeError> {
         let name = CString::new(name).expect("CString::new failed");
         let function =
             unsafe { wasm_runtime_lookup_function(instance.get_inner_instance(), name.as_ptr()) };
@@ -46,7 +49,7 @@ impl<'a> Function<'a> {
     #[allow(non_upper_case_globals)]
     fn parse_result(
         &self,
-        instance: &'a Instance<'a>,
+        instance: &Instance<'instance>,
         result: Vec<u32>,
     ) -> Result<WasmValue, RuntimeError> {
         let result_count =
@@ -81,7 +84,7 @@ impl<'a> Function<'a> {
     /// Return `RuntimeError::ExecutionError` if failed.
     pub fn call(
         &self,
-        instance: &'a Instance<'a>,
+        instance: &'instance Instance<'instance>,
         params: &Vec<WasmValue>,
     ) -> Result<WasmValue, RuntimeError> {
         // params -> Vec<u32>

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -21,20 +21,20 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Instance<'a> {
+pub struct Instance<'module> {
     instance: wasm_module_inst_t,
-    _phantom: PhantomData<Module<'a>>,
+    _phantom: PhantomData<Module<'module>>,
 }
 
-impl<'a> Instance<'a> {
+impl<'module> Instance<'module> {
     /// instantiate a module with stack size
     ///
     /// # Error
     ///
     /// Return `RuntimeError::CompilationError` if failed.
     pub fn new(
-        runtime: &'a Runtime<'a>,
-        module: &'a Module<'a>,
+        runtime: &Runtime,
+        module: &'module Module<'module>,
         stack_size: u32,
     ) -> Result<Self, RuntimeError> {
         Self::new_with_args(runtime, module, stack_size, 0)
@@ -48,8 +48,8 @@ impl<'a> Instance<'a> {
     ///
     /// Return `RuntimeError::CompilationError` if failed.
     pub fn new_with_args(
-        _runtime: &'a Runtime<'a>,
-        module: &'a Module<'a>,
+        _runtime: &Runtime,
+        module: &'module Module<'module>,
         stack_size: u32,
         heap_size: u32,
     ) -> Result<Self, RuntimeError> {

--- a/src/module.rs
+++ b/src/module.rs
@@ -28,23 +28,23 @@ use wamr_sys::{
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct Module<'a> {
+pub struct Module<'runtime> {
     name: String,
     module: wasm_module_t,
     // to keep the module content in memory
     content: Vec<u8>,
     wasi_ctx: WasiCtx,
-    _phantom: PhantomData<Runtime<'a>>,
+    _phantom: PhantomData<&'runtime Runtime>,
 }
 
-impl<'a> Module<'a> {
+impl<'runtime> Module<'runtime> {
     /// compile a module with the given wasm file path, use the file name as the module name
     ///
     /// # Error
     ///
     /// If the file does not exist or the file cannot be read, an `RuntimeError::WasmFileFSError` will be returned.
     /// If the wasm file is not a valid wasm file, an `RuntimeError::CompilationError` will be returned.
-    pub fn from_file(runtime: &'a Runtime<'a>, wasm_file: &Path) -> Result<Self, RuntimeError> {
+    pub fn from_file(runtime: &'runtime Runtime, wasm_file: &Path) -> Result<Self, RuntimeError> {
         let name = wasm_file.file_name().unwrap().to_str().unwrap();
         let mut wasm_file = File::open(wasm_file)?;
 
@@ -61,7 +61,7 @@ impl<'a> Module<'a> {
     /// If the file does not exist or the file cannot be read, an `RuntimeError::WasmFileFSError` will be returned.
     /// If the wasm file is not a valid wasm file, an `RuntimeError::CompilationError` will be returned.
     pub fn from_vec(
-        _runtime: &'a Runtime<'a>,
+        _runtime: &'runtime Runtime,
         mut content: Vec<u8>,
         name: &str,
     ) -> Result<Self, RuntimeError> {


### PR DESCRIPTION
Just removed lifetime for `Runtime` since it doesn't depend on anything and rename others lifetimes for clarity. Nothing fancy.