### PR TITLE
Maintain sufficient allocated space in the vector

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,4 @@ RUN cd /tmp \
   && chmod a+x llvm.sh \
   && ./llvm.sh 15
 
+RUN ln -sf /usr/bin/lldb-15 /usr/bin/lldb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,11 @@
     },
     "vscode": {
       "extensions": [
-        "bungcip.better-toml",
         "dtsvet.vscode-wasm",
         "fill-labs.dependi",
         "rust-lang.rust-analyzer",
         "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml",
         "vadimcn.vscode-lldb"
       ],
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -8,11 +8,12 @@
 
 use std::{ffi::CString, marker::PhantomData};
 use wamr_sys::{
-    wasm_exec_env_t, wasm_func_get_result_count, wasm_func_get_result_types, wasm_function_inst_t,
-    wasm_runtime_call_wasm, wasm_runtime_get_exception, wasm_runtime_get_exec_env_singleton,
-    wasm_runtime_get_wasi_exit_code, wasm_runtime_lookup_function, wasm_valkind_enum_WASM_F32,
-    wasm_valkind_enum_WASM_F64, wasm_valkind_enum_WASM_I32, wasm_valkind_enum_WASM_I64,
-    wasm_valkind_t,
+    wasm_exec_env_t, wasm_func_get_param_count, wasm_func_get_result_count,
+    wasm_func_get_result_types, wasm_function_inst_t, wasm_runtime_call_wasm,
+    wasm_runtime_get_exception, wasm_runtime_get_exec_env_singleton,
+    wasm_runtime_get_wasi_exit_code, wasm_runtime_lookup_function,
+    wasm_valkind_enum_WASM_EXTERNREF, wasm_valkind_enum_WASM_F32, wasm_valkind_enum_WASM_F64,
+    wasm_valkind_enum_WASM_FUNCREF, wasm_valkind_enum_WASM_I32, wasm_valkind_enum_WASM_I64,
 };
 
 use crate::{
@@ -51,29 +52,56 @@ impl<'instance> Function<'instance> {
         &self,
         instance: &Instance<'instance>,
         result: Vec<u32>,
-    ) -> Result<WasmValue, RuntimeError> {
+    ) -> Result<Vec<WasmValue>, RuntimeError> {
         let result_count =
             unsafe { wasm_func_get_result_count(self.function, instance.get_inner_instance()) };
         if result_count == 0 {
-            return Ok(WasmValue::Void);
+            return Ok(vec![WasmValue::Void]);
         }
 
-        let mut result_type: wasm_valkind_t = 0;
+        let mut result_types = vec![0u8; result_count as usize];
         unsafe {
             wasm_func_get_result_types(
                 self.function,
                 instance.get_inner_instance(),
-                &mut result_type,
+                result_types.as_mut_ptr(),
             );
         }
 
-        match result_type as u32 {
-            wasm_valkind_enum_WASM_I32 => Ok(WasmValue::decode_to_i32(result)),
-            wasm_valkind_enum_WASM_I64 => Ok(WasmValue::decode_to_i64(result)),
-            wasm_valkind_enum_WASM_F32 => Ok(WasmValue::decode_to_f32(result)),
-            wasm_valkind_enum_WASM_F64 => Ok(WasmValue::decode_to_f64(result)),
-            _ => Err(RuntimeError::NotImplemented),
+        let mut results = Vec::with_capacity(result_types.len());
+        let mut index: usize = 0;
+
+        for result_type in result_types.iter() {
+            match *result_type as u32 {
+                wasm_valkind_enum_WASM_I32
+                | wasm_valkind_enum_WASM_FUNCREF
+                | wasm_valkind_enum_WASM_EXTERNREF => {
+                    results.push(WasmValue::decode_to_i32(vec![result[index]]));
+                    index += 1;
+                }
+                wasm_valkind_enum_WASM_I64 => {
+                    results.push(WasmValue::decode_to_i64(vec![
+                        result[index],
+                        result[index + 1],
+                    ]));
+                    index += 2;
+                }
+                wasm_valkind_enum_WASM_F32 => {
+                    results.push(WasmValue::decode_to_f32(vec![result[index]]));
+                    index += 1;
+                }
+                wasm_valkind_enum_WASM_F64 => {
+                    results.push(WasmValue::decode_to_f64(vec![
+                        result[index],
+                        result[index + 1],
+                    ]));
+                    index += 2;
+                }
+                _ => return Err(RuntimeError::NotImplemented),
+            }
         }
+
+        Ok(results)
     }
 
     /// execute an export function.
@@ -86,20 +114,32 @@ impl<'instance> Function<'instance> {
         &self,
         instance: &'instance Instance<'instance>,
         params: &Vec<WasmValue>,
-    ) -> Result<WasmValue, RuntimeError> {
-        // params -> Vec<u32>
-        let mut argv = Vec::new();
+    ) -> Result<Vec<WasmValue>, RuntimeError> {
+        let param_count =
+            unsafe { wasm_func_get_param_count(self.function, instance.get_inner_instance()) };
+        if param_count > params.len() as u32 {
+            return Err(RuntimeError::ExecutionError(ExecError {
+                message: "invalid parameters".to_string(),
+                exit_code: 0xff,
+            }));
+        }
+
+        // Maintain sufficient allocated space in the vector rather than just declaring its capacity.
+        let result_count =
+            unsafe { wasm_func_get_result_count(self.function, instance.get_inner_instance()) };
+        let capacity = std::cmp::max(param_count, result_count) as usize * 2;
+        let mut argv = Vec::with_capacity(capacity);
         for p in params {
             argv.append(&mut p.encode());
         }
+        argv.resize(capacity, 0);
 
-        let argc = params.len();
         let call_result: bool;
         unsafe {
             let exec_env: wasm_exec_env_t =
                 wasm_runtime_get_exec_env_singleton(instance.get_inner_instance());
             call_result =
-                wasm_runtime_call_wasm(exec_env, self.function, argc as u32, argv.as_mut_ptr());
+                wasm_runtime_call_wasm(exec_env, self.function, param_count, argv.as_mut_ptr());
         };
 
         if !call_result {
@@ -113,6 +153,7 @@ impl<'instance> Function<'instance> {
             }
         }
 
+        // there is no out of bounds problem, because we precalculated the safe vec size
         self.parse_result(instance, argv)
     }
 }
@@ -128,16 +169,28 @@ mod tests {
         let runtime = Runtime::new().unwrap();
 
         // (module
-        //   (func (export "add") (param i32 i32) (result i32)
-        //     (local.get 0)
+        //   (func (export "add") (param i64 i32) (result i32 i64)
         //     (local.get 1)
+        //     (i32.const 32)
         //     (i32.add)
+        //     (local.get 0)
+        //     (i64.const 64)
+        //     (i64.add)
+        //   )
+        //
+        //   (func (export "multi-result") (result i32 i64 i32)
+        //     (i32.const 1)
+        //     (i64.const 2)
+        //     (i32.const 3)
         //   )
         // )
         let binary = vec![
-            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7f,
-            0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64,
-            0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b,
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0E, 0x02, 0x60, 0x02, 0x7E,
+            0x7F, 0x02, 0x7F, 0x7E, 0x60, 0x00, 0x03, 0x7F, 0x7E, 0x7F, 0x03, 0x03, 0x02, 0x00,
+            0x01, 0x07, 0x16, 0x02, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0C, 0x6D, 0x75, 0x6C,
+            0x74, 0x69, 0x2D, 0x72, 0x65, 0x73, 0x75, 0x6C, 0x74, 0x00, 0x01, 0x0A, 0x18, 0x02,
+            0x0D, 0x00, 0x20, 0x01, 0x41, 0x20, 0x6A, 0x20, 0x00, 0x42, 0xC0, 0x00, 0x7C, 0x0B,
+            0x08, 0x00, 0x41, 0x01, 0x42, 0x02, 0x41, 0x03, 0x0B,
         ];
         let binary = binary.into_iter().map(|c| c as u8).collect::<Vec<u8>>();
 
@@ -149,19 +202,37 @@ mod tests {
         assert!(instance.is_ok());
         let instance: &Instance = &instance.unwrap();
 
+        //
+        // run add()
+        //
+
         let function = Function::find_export_func(instance, "add");
         assert!(function.is_ok());
         let function = function.unwrap();
 
-        let params: Vec<WasmValue> = vec![WasmValue::I32(3), WasmValue::I32(6)];
+        let params: Vec<WasmValue> = vec![WasmValue::I64(10), WasmValue::I32(20)];
         let call_result = function.call(instance, &params);
         assert!(call_result.is_ok());
-        assert_eq!(call_result.unwrap(), WasmValue::I32(9));
+        assert_eq!(
+            call_result.unwrap(),
+            vec![WasmValue::I32(52), WasmValue::I64(74)]
+        );
 
-        let params: Vec<WasmValue> = vec![WasmValue::I32(128), WasmValue::I32(256)];
+        //
+        // run multi-result()
+        //
+
+        let function = Function::find_export_func(instance, "multi-result");
+        assert!(function.is_ok());
+        let function = function.unwrap();
+
+        let params: Vec<WasmValue> = Vec::new();
         let call_result = function.call(instance, &params);
         assert!(call_result.is_ok());
-        assert_eq!(call_result.unwrap(), WasmValue::I32(384));
+        assert_eq!(
+            call_result.unwrap(),
+            vec![WasmValue::I32(1), WasmValue::I64(2), WasmValue::I32(3)]
+        );
     }
 
     #[test]
@@ -190,11 +261,11 @@ mod tests {
 
         let params: Vec<WasmValue> = vec![WasmValue::I32(9), WasmValue::I32(27)];
         let result = function.call(instance, &params);
-        assert_eq!(result.unwrap(), WasmValue::I32(9));
+        assert_eq!(result.unwrap(), vec![WasmValue::I32(9)]);
 
         let params: Vec<WasmValue> = vec![WasmValue::I32(0), WasmValue::I32(27)];
         let result = function.call(instance, &params);
-        assert_eq!(result.unwrap(), WasmValue::I32(27));
+        assert_eq!(result.unwrap(), vec![WasmValue::I32(27)]);
     }
 
     #[test]

--- a/src/host_function.rs
+++ b/src/host_function.rs
@@ -101,6 +101,6 @@ mod tests {
 
         let params: Vec<WasmValue> = vec![WasmValue::I32(8), WasmValue::I32(8)];
         let result = function.call(instance, &params);
-        assert_eq!(result.unwrap(), WasmValue::I32(116));
+        assert_eq!(result.unwrap(), vec![WasmValue::I32(116)]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //!
 //!     let params: Vec<WasmValue> = vec![WasmValue::I32(9), WasmValue::I32(27)];
 //!     let result = function.call(&instance, &params)?;
-//!     assert_eq!(result, WasmValue::I32(9));
+//!     assert_eq!(result, vec![WasmValue::I32(9)]);
 //!
 //!     Ok(())
 //! }
@@ -134,7 +134,7 @@
 //!
 //!     let params: Vec<WasmValue> = vec![WasmValue::I32(9), WasmValue::I32(27)];
 //!     let result = function.call(&instance, &params)?;
-//!     assert_eq!(result, WasmValue::I32(136));
+//!     assert_eq!(result, vec![WasmValue::I32(136)]);
 //!
 //!     Ok(())
 //! }


### PR DESCRIPTION
`wasm_runtime_call_wasm()` is called with `argv`
used to pass parameters, and the callee reuses
`argv` to store the results. Therefore, `argv`
must be long enough to hold the results.

Typically, a vector's length changes with
operations, but in our scenario, `append()`
operation occurs outside of our control. If there
are more results than parameters, the vector will
end up with an incorrect length unless we
proactively manage it.

Update Dockerfile and devcontainer configuration

fix #97 